### PR TITLE
add repository to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "lint": "./node_modules/.bin/eslint src",
     "test": "jest"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/delorge/stylelint-config-lost.git"
+  },
   "keywords": [
     "stylelint",
     "stylelint-config",


### PR DESCRIPTION
This will add a link to the github repo on [npm](https://www.npmjs.com/package/stylelint-config-lost) and will open the github page when running `npm repo stylelint-config-lost`